### PR TITLE
dts:qcom: correct gpio pins for flashlight

### DIFF
--- a/arch/arm/boot/dts/qcom/15399/msm8916-camera-sensor-mtp-15399.dtsi
+++ b/arch/arm/boot/dts/qcom/15399/msm8916-camera-sensor-mtp-15399.dtsi
@@ -50,12 +50,13 @@
 		pinctrl-names = "cam_flash_default", "cam_flash_suspend";
 		pinctrl-0 = <&cam_sensor_flash_default>;
 		pinctrl-1 = <&cam_sensor_flash_sleep>;
-		gpios = <&msm_gpio 32 0>, <&msm_gpio 31 0>;
+		gpios = <&msm_gpio 32 0>, <&msm_gpio 31 0>, <&pm8916_gpios 2 0>;
 		qcom,gpio-flash-en = <0>;
+		qcom,gpio-flash-now = <1>;
+		qcom,gpio-vio = <2>;
 		qcom,gpio-req-tbl-num = <0 1 2>;
 		qcom,gpio-req-tbl-flags = <0 0 0>;
-		qcom,gpio-req-tbl-label = "FLASH_EN", "FLASH_NOW";
-		qcom,gpio-flash-now = <1>;
+		qcom,gpio-req-tbl-label = "FLASH_EN", "FLASH_NOW", "Gpio-vio";
 		qcom,current = <200>;
 		qcom,max-current = <950>;
 		linux,name = "flashlight";


### PR DESCRIPTION
Flashlight is working now : )
Thanks to @AndroiableDroid